### PR TITLE
Fix ESP32 bugs

### DIFF
--- a/src/Protocental_FDC1004.cpp
+++ b/src/Protocental_FDC1004.cpp
@@ -49,12 +49,10 @@ uint16_t FDC1004::read16(uint8_t reg)
   Wire.write(reg);
   Wire.endTransmission();
   uint16_t value;
-  Wire.beginTransmission(_addr);
   Wire.requestFrom(_addr, (uint8_t)2);
   value = Wire.read();
   value <<= 8;
   value |= Wire.read();
-  Wire.endTransmission();
   return value;
 }
 

--- a/src/Protocental_FDC1004.cpp
+++ b/src/Protocental_FDC1004.cpp
@@ -86,6 +86,7 @@ uint8_t FDC1004::triggerSingleMeasurement(uint8_t measurement, uint8_t rate)
     trigger_data |= 0 << 8; //repeat disabled
     trigger_data |= (1 << (7-measurement)); // 0 > bit 7, 1 > bit 6, etc
     write16(FDC_REGISTER, trigger_data);
+    return 0;
 }
 
 /**


### PR DESCRIPTION
This PR fixes two bugs in the code which prevent the library from working on ESP32:

- Missing return statement in `triggerSingleMeasurement` (fixed in https://github.com/beshaya/FDC1004/pull/11/files upstream)
- Use of `Wire.beginTransmission()` and `Wire.endTransmission()` around read operations (https://github.com/beshaya/FDC1004/issues/6)

This should also resolve #5.