### PR TITLE
Properly using the 24-bit value

### DIFF
--- a/src/Protocental_FDC1004.cpp
+++ b/src/Protocental_FDC1004.cpp
@@ -472,14 +472,9 @@ uint8_t FDC1004::getMeasurementDelay() const
     }
 }
 
-float FDC1004::convertToPicofarads(int16_t raw_value, uint8_t capdac) const
+float FDC1004::convertToPicofarads(int32_t raw_value, uint8_t capdac) const
 {
-    // Convert from raw measurement to picofarads
-    float capacitance_af = (float)FDC1004_ATTOFARADS_UPPER_WORD * (float)raw_value;  // attofarads
-    float capacitance_pf = capacitance_af / 1000000.0f;                              // Convert to picofarads
-    capacitance_pf += ((float)FDC1004_FEMTOFARADS_CAPDAC * (float)capdac) / 1000.0f; // Add CAPDAC offset
-
-    return capacitance_pf;
+    return ((float)raw_value / (float)FDC1004_PICOFARADS_DIVISOR) + (FDC1004_PICOFARADS_CAPDAC * (float)capdac);
 }
 
 bool FDC1004::isValidChannel(uint8_t channel) const

--- a/src/Protocental_FDC1004.cpp
+++ b/src/Protocental_FDC1004.cpp
@@ -341,7 +341,14 @@ fdc1004_error_t FDC1004::getRawCapacitance(fdc1004_channel_t channel, fdc1004_ra
         return result;
     }
 
-    value->value = (int16_t)raw_measurement[0];
+    uint32_t combined = ((uint32_t)raw_measurement[0] << 8) | ((raw_measurement[1] >> 8) & 0xFF);
+
+    if (combined & 0x800000)
+    {
+        combined |= 0xFF000000;
+    }
+
+    value->value = static_cast<int32_t>(combined);
     value->capdac = capdac;
 
     return FDC1004_SUCCESS;

--- a/src/Protocentral_FDC1004.h
+++ b/src/Protocentral_FDC1004.h
@@ -136,7 +136,7 @@ typedef enum {
  * @brief Raw measurement data structure
  */
 typedef struct {
-    int16_t value;      ///< Raw capacitance measurement value
+    int32_t value;      ///< Raw capacitance measurement value
     uint8_t capdac;     ///< CAPDAC offset used for this measurement
 } fdc1004_raw_measurement_t;
 

--- a/src/Protocentral_FDC1004.h
+++ b/src/Protocentral_FDC1004.h
@@ -87,6 +87,14 @@
 #define ATTOFARADS_UPPER_WORD (457) //number of attofarads for each 8th most lsb (lsb of the upper 16 bit half-word)
 #define FEMTOFARADS_CAPDAC (3028) //number of femtofarads for each lsb of the capdac
 
+// Conversion constants
+constexpr float FDC1004_PICOFARADS_DIVISOR = 0x80000;
+constexpr float FDC1004_PICOFARADS_CAPDAC = 3.125f;
+
+// Measurement bounds for CAPDAC adjustment
+constexpr int32_t FDC1004_UPPER_BOUND = 0x7FFFFF;
+constexpr int32_t FDC1004_LOWER_BOUND = 0x800000;
+
 // =============================================================================
 // Data Types and Enumerations
 // =============================================================================
@@ -380,7 +388,7 @@ private:
      * @param capdac CAPDAC value used
      * @return Capacitance in picofarads
      */
-    float convertToPicofarads(int16_t raw_value, uint8_t capdac) const;
+    float convertToPicofarads(int32_t raw_value, uint8_t capdac) const;
     
     /**
      * @brief Validate input parameters


### PR DESCRIPTION
The FDC1004 outputs measurements in 24-bit format (see the data sheet attached).

> 6.6.1.1 Capacitive Measurement Registers
The capacitance measurement registers are 24-bit result registers in binary format (the 8 LSBs D[7:0] are always
0x00).

So this fix restores previously ignored LSB and also handles negative values.

[fdc1004.pdf](https://github.com/user-attachments/files/24869633/fdc1004.pdf)
